### PR TITLE
Fix method name in interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # VSlack - Go
-### Version 1.1.0
+### Version 1.1.1
 Send messages to slack using a slack incoming web hook in Go.
 
 ## Examples
@@ -66,6 +66,9 @@ func attach() {
 
 
 ## Change Log
+
+### 1.1.1
+- Fix name in Interface of `SetIncomingWebhookURI`
 
 ### 1.1.0
 - Add implementation for SendAsync

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # VSlack - Go
-### Version 1.1.1
+### Version 1.2.0
 Send messages to slack using a slack incoming web hook in Go.
 
 ## Examples
@@ -67,7 +67,7 @@ func attach() {
 
 ## Change Log
 
-### 1.1.1
+### 1.2.0
 - Fix name in Interface of `SetIncomingWebhookURI`
 
 ### 1.1.0

--- a/vslack.go
+++ b/vslack.go
@@ -6,7 +6,7 @@ import (
 
 // Interface is a VSlack interface
 type Interface interface {
-	SetIncomingwebHookURI(h string) *VSlack
+	SetIncomingWebhookURI(h string) *VSlack
 	SetChannel(c string) *VSlack
 	SetUsername(u string) *VSlack
 	SetIconEmoji(i string) *VSlack


### PR DESCRIPTION
## Problem
- Interface has the method name as `SetIncomingwebHookURI` and VSlack implements it as `SetIncomingWebhookURI`

## Solution
- Rename method in Interface to match the one in the VSlack implementation

---
@twiebe-va 